### PR TITLE
修复文件上传时提交数组数据的 bug

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -107,10 +107,15 @@ class Client
     {
         $multipart = [];
 
-        foreach (\array_merge($files, $form) as $name => $contents) {
+        foreach ($files as $name => $contents) {
+            $contents = \is_resource($contents) ?: \fopen($contents, 'r');
+            $multipart[] = \compact('name', 'contents');
+        }
+
+        foreach ($form as $name => $contents) {
             $multipart = array_merge($multipart, $this->normalizeMultipartField($name, $contents));
         }
-        
+
         return $this->request($url, 'POST', ['query' => $query, 'multipart' => $multipart]);
     }
 


### PR DESCRIPTION
在使用 upload 上传文件时，有时我们需要上传一些数组数据，如：

```php
$client->upload('/upload', $file, [
    "xxx" => '',
    "extends" => [
        "a" => 1
   ]
])
```
但目前的 sdk 只支持一维数组，不支持多维数组。基于此，我么通过构造 http form-data 的请求特性，来支持多维数组。

```http
POST /test/storage/pull HTTP/1.1

--2118d6a29b05e5d16974d20b6527424804451e65
Content-Disposition: form-data; name="configs[filed][0]"

value1
--2118d6a29b05e5d16974d20b6527424804451e65
Content-Disposition: form-data; name="configs[filed][1]"

value2
```
