### PR TITLE
php8中报错 Error: Undefined constant CURLOPT_IPRESOLVE，已修复

### DIFF
--- a/src/Traits/HasHttpRequests.php
+++ b/src/Traits/HasHttpRequests.php
@@ -29,7 +29,7 @@ trait HasHttpRequests
      */
     protected static $defaults = [
         'curl' => [
-            CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+            'CURLOPT_IPRESOLVE' => 'CURL_IPRESOLVE_V4',
         ],
     ];
 


### PR DESCRIPTION
Traits\CURLOPT_IPRESOLVE  php8中报错 Error: Undefined constant CURLOPT_IPRESOLVE，已修复  。